### PR TITLE
Fixing porting issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ opencv-contrib-python
 Pillow
 tqdm
 tensorflow
-keras
-git+https://www.github.com/keras-team/keras-contrib.git
+tensorflow-addons


### PR DESCRIPTION
Removing all references to vanilla keras (true compatibility with tensorflow is now deprecated)
Pulling InstanceNormalization from tensorflow_addons instead of keras-contrib (deprecated)
